### PR TITLE
Fix CI by using separate action to install PlatformIO environment

### DIFF
--- a/.github/actions/platformio-env/action.yml
+++ b/.github/actions/platformio-env/action.yml
@@ -1,0 +1,15 @@
+name: 'platformio-env'
+description: 'Install Platform.IO environment'
+runs:
+  using: "composite"
+  steps:
+    - id: install-platformio-env
+      shell: bash
+      run: |
+        apt update
+        export DEBIAN_FRONTEND=noninteractive
+        apt install -y git curl python3 python3-pip python3-venv git cmake
+        curl -fsSL -o get-platformio.py https://raw.githubusercontent.com/platformio/platformio-core-installer/master/get-platformio.py
+        python3 get-platformio.py
+        echo 'export PATH=$PATH:~/.platformio/penv/bin' >> ~/.bashrc
+

--- a/.github/actions/platformio-env/action.yml
+++ b/.github/actions/platformio-env/action.yml
@@ -8,7 +8,7 @@ runs:
       run: |
         sudo apt-get update
         export DEBIAN_FRONTEND=noninteractive
-        apt install -y git curl python3 python3-pip python3-venv git cmake
+        sudo apt-get install -y git curl python3 python3-pip python3-venv git cmake
         curl -fsSL -o get-platformio.py https://raw.githubusercontent.com/platformio/platformio-core-installer/master/get-platformio.py
         python3 get-platformio.py
         echo 'export PATH=$PATH:~/.platformio/penv/bin' >> ~/.bashrc

--- a/.github/actions/platformio-env/action.yml
+++ b/.github/actions/platformio-env/action.yml
@@ -6,7 +6,7 @@ runs:
     - id: install-platformio-env
       shell: bash
       run: |
-        apt update
+        sudo apt-get update
         export DEBIAN_FRONTEND=noninteractive
         apt install -y git curl python3 python3-pip python3-venv git cmake
         curl -fsSL -o get-platformio.py https://raw.githubusercontent.com/platformio/platformio-core-installer/master/get-platformio.py

--- a/.github/workflows/reusable-platformio-ci.yml
+++ b/.github/workflows/reusable-platformio-ci.yml
@@ -130,5 +130,5 @@ jobs:
         env:
           ROS_DISTRO: ${{ inputs.ros_distro }}
         run: |
-          cd firmware
+          cd ./repo/firmware
           pio run -e ${{ matrix.env }}

--- a/.github/workflows/reusable-platformio-ci.yml
+++ b/.github/workflows/reusable-platformio-ci.yml
@@ -27,25 +27,15 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.reference }}
+          path: repo
 
-      # Cache dependencies to speed up workflows
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/pip
-            ~/.platformio/.cache
-          key: ${{ runner.os }}-pio
-
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.9'
-
-      - name: Install PlatformIO Core
-        run: pip install --upgrade platformio
+      - name: Install environment
+        uses: ./repo/.github/actions/platformio-env
 
       - name: Build Calibration
         run: |
-          cd calibration
+          export PATH=$PATH:~/.platformio/penv/bin
+          cd repo/calibration
           pio run
 
 
@@ -94,33 +84,6 @@ jobs:
         with:
           ref: ${{ inputs.reference }}
           path: repo
-
-      # # speed up workflows by caching dependencies
-      # - uses: actions/cache@v3
-      #   with:
-      #     path: |
-      #       ~/.cache/pip
-      #       ~/.platformio/.cache
-      #     key: ${{ runner.os }}-pio
-      
-      # - uses: actions/setup-python@v4
-      #   with:
-      #     python-version: '3.10'
-
-      # - name: Install PlatformIO Core
-      #   run: pip3 install --upgrade platformio
-
-      # - name: Initialize Platformio, manually create .platformio and penv if needed
-      #   run: |
-      #     pio --version
-      #     if [ ! -d ~/.platformio ]; then
-      #       mkdir ~/.platformio
-      #     fi
-          
-      #     if [ ! -d ~/.platformio/penv ]; then
-      #       cd ~/.platformio
-      #       python3 -m venv penv
-      #     fi
 
       - name: Install environment
         uses: ./repo/.github/actions/platformio-env

--- a/.github/workflows/reusable-platformio-ci.yml
+++ b/.github/workflows/reusable-platformio-ci.yml
@@ -129,6 +129,8 @@ jobs:
       - name: Build Firmware
         env:
           ROS_DISTRO: ${{ inputs.ros_distro }}
+        shell: bash
         run: |
-          cd ./repo/firmware
+          export PATH=$PATH:~/.platformio/penv/bin
+          cd repo/firmware
           pio run -e ${{ matrix.env }}

--- a/.github/workflows/reusable-platformio-ci.yml
+++ b/.github/workflows/reusable-platformio-ci.yml
@@ -29,6 +29,14 @@ jobs:
           ref: ${{ inputs.reference }}
           path: repo
 
+      # Cache dependencies to speed up workflows
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
+
       - name: Install environment
         uses: ./repo/.github/actions/platformio-env
 
@@ -84,6 +92,14 @@ jobs:
         with:
           ref: ${{ inputs.reference }}
           path: repo
+
+      # Cache dependencies to speed up workflows
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
 
       - name: Install environment
         uses: ./repo/.github/actions/platformio-env

--- a/.github/workflows/reusable-platformio-ci.yml
+++ b/.github/workflows/reusable-platformio-ci.yml
@@ -93,33 +93,37 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.reference }}
+          path: repo
 
-      # speed up workflows by caching dependencies
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/pip
-            ~/.platformio/.cache
-          key: ${{ runner.os }}-pio
+      # # speed up workflows by caching dependencies
+      # - uses: actions/cache@v3
+      #   with:
+      #     path: |
+      #       ~/.cache/pip
+      #       ~/.platformio/.cache
+      #     key: ${{ runner.os }}-pio
       
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
+      # - uses: actions/setup-python@v4
+      #   with:
+      #     python-version: '3.10'
 
-      - name: Install PlatformIO Core
-        run: pip3 install --upgrade platformio
+      # - name: Install PlatformIO Core
+      #   run: pip3 install --upgrade platformio
 
-      - name: Initialize Platformio, manually create .platformio and penv if needed
-        run: |
-          pio --version
-          if [ ! -d ~/.platformio ]; then
-            mkdir ~/.platformio
-          fi
+      # - name: Initialize Platformio, manually create .platformio and penv if needed
+      #   run: |
+      #     pio --version
+      #     if [ ! -d ~/.platformio ]; then
+      #       mkdir ~/.platformio
+      #     fi
           
-          if [ ! -d ~/.platformio/penv ]; then
-            cd ~/.platformio
-            python3 -m venv penv
-          fi
+      #     if [ ! -d ~/.platformio/penv ]; then
+      #       cd ~/.platformio
+      #       python3 -m venv penv
+      #     fi
+
+      - name: Install environment
+        uses: ./repo/.github/actions/platformio-env
           
       # Build the firmware for each environment in parallel
       - name: Build Firmware


### PR DESCRIPTION
Fixes Rolling firmware failing to build in CI when installing [micro_ros_platformio](https://github.com/micro-ROS/micro_ros_platformio/tree/main) dependency. 

I traced the issue back to [this recent merged PR](https://github.com/micro-ROS/micro_ros_platformio/pull/108) in that project. 

I looked at the way micro_ros_platformio handles CI, and saw that they use a separate action to install PlatformIO on the CI runners. I copied this action into this repository and changed the workflow to use it. This fixed the CI build failure for Rolling, sped up the build time, and simplified the workflow structure.  

@mergify backport humble galactic foxy